### PR TITLE
refactored getSeedFactoryFunction to just getSeed cause that is much …

### DIFF
--- a/src/scripts/seeds/seedsHelpers.js
+++ b/src/scripts/seeds/seedsHelpers.js
@@ -6,24 +6,24 @@ import { createSunflower } from './sunflower.js';
 import { createWheat } from './wheat.js';
 
 /**
- * Given a plant type, return that plant's corresponding seed factory function (e.g., "Asparagus" -> createAsparagus).
+ * Given a plant type, return that plant type's corresponding seed object.
  * Throws Error if plant type is not recognized as a valid plant type.
- * @param {String} plantType The name of the plant to obtain the seed factory function for.
+ * @param {String} plantType The name of the plant to obtain the seed for.
  */
-export const getSeedFactoryFunction = plantType => {
+export const getSeed = plantType => {
   switch(plantType) {
     case 'Asparagus':
-      return createAsparagus;
+      return createAsparagus();
     case 'Corn':
-      return createCorn;
+      return createCorn();
     case 'Potato':
-      return createPotato;
+      return createPotato();
     case 'Soybean':
-      return createSoybean;
+      return createSoybean();
     case 'Sunflower':
-      return createSunflower;
+      return createSunflower();
     case 'Wheat':
-      return createWheat;
+      return createWheat();
     default:
       throw new Error(`${plantType} is not a valid plant type.`);
   }

--- a/src/scripts/tractor.js
+++ b/src/scripts/tractor.js
@@ -1,12 +1,12 @@
 import { addPlant } from './field.js';
-import { getSeedFactoryFunction } from './seeds/seedsHelpers.js';
+import { getSeed } from './seeds/seedsHelpers.js';
 
 export const plantSeeds = plan => {
   plan.forEach(row => {
     row.forEach(plantType => {
       try {
-        const seedFactoryFunction = getSeedFactoryFunction(plantType);
-        addPlant(seedFactoryFunction());
+        const seed = getSeed(plantType);
+        addPlant(seed);
       }
       catch(e) {
         console.log(e.message);


### PR DESCRIPTION
1. Ensure that `getSeed` as defined in `seedHelpers.js` will return the corresponding seed object for the string of `plantType` passed in, or will throw an error if the `plantType` is not recognized.
2. Ensure that `tractor.js` properly uses the `getSeed` function.